### PR TITLE
Made the viewer work on non-GPU devices

### DIFF
--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -6,6 +6,7 @@ from array import array
 from collections import namedtuple
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
+import torch
 
 import imgui
 import moderngl_window
@@ -77,8 +78,8 @@ class Viewer(moderngl_window.WindowConfig):
     resource_dir = Path(__file__).parent / "shaders"
     size_mult = 1.0
     samples = 4
-    if sys.platform == "darwin":
-        gl_version = (4, 0)
+    if sys.platform == "darwin" or not(torch.cuda.is_available()):
+        gl_version = (4, 1)
     else:
         gl_version = (4, 5)
     window_type = None

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -502,6 +502,7 @@ class Viewer(moderngl_window.WindowConfig):
         :param args: The arguments passed to `config_cls` constructor.
         :param log: Whether to log to the console.
         """
+        print(self.gl_version)
         self._init_scene()
 
         self.export_animation_range[-1] = self.scene.n_frames - 1

--- a/examples/load_export_AMASS.py
+++ b/examples/load_export_AMASS.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+import os
+import numpy as np
+from aitviewer.configuration import CONFIG as C
+from aitviewer.renderables.point_clouds import PointClouds
+
+from aitviewer.renderables.smpl import SMPLSequence
+from aitviewer.viewer import Viewer
+
+
+v = Viewer()
+v.scene.camera.position = np.array([10.0, 2.5, 0.0])
+seq_export = SMPLSequence.from_npz(file=os.path.join(C.export_dir, "SMPL/AMASS Running.npz"), z_up=True)
+ptc_export = PointClouds(seq_export.vertices, position=np.array([1.0, 0.0, 0.0]), z_up=True)
+v.scene.add(seq_export, ptc_export)
+v.run()


### PR DESCRIPTION
Resolves Issue #3 

Added to the if condition that checks whether the system runs on MAC OS (`sys.platform == "darwin"`) the check if cuda is available. If the system runs on MAC OS or cuda is not available, the OpenGL version will be 4.1. Else the OpenGL version will be 4.5

For testing, I added a print statement that prints your GL version when you run the viewer. If you do not have cuda (you have to install the GPU-version of pytorch for that), it should print `(4,1)`. If you have a device with cuda support and the GPU-version of PyTorch installed, it should print `(4,5)`.