### PR TITLE
Made the viewer work on non-GPU devices

### DIFF
--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -6,6 +6,7 @@ from array import array
 from collections import namedtuple
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
+import torch
 
 import imgui
 import moderngl_window
@@ -77,8 +78,8 @@ class Viewer(moderngl_window.WindowConfig):
     resource_dir = Path(__file__).parent / "shaders"
     size_mult = 1.0
     samples = 4
-    if sys.platform == "darwin":
-        gl_version = (4, 0)
+    if sys.platform == "darwin" or not(torch.cuda.is_available()):
+        gl_version = (4, 1)
     else:
         gl_version = (4, 5)
     window_type = None

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -502,7 +502,6 @@ class Viewer(moderngl_window.WindowConfig):
         :param args: The arguments passed to `config_cls` constructor.
         :param log: Whether to log to the console.
         """
-        print(self.gl_version)
         self._init_scene()
 
         self.export_animation_range[-1] = self.scene.n_frames - 1

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -502,6 +502,7 @@ class Viewer(moderngl_window.WindowConfig):
         :param args: The arguments passed to `config_cls` constructor.
         :param log: Whether to log to the console.
         """
+        print(self.gl_version)
         self._init_scene()
 
         self.export_animation_range[-1] = self.scene.n_frames - 1


### PR DESCRIPTION
Resolves Issue https://github.com/luni1024/Style-Transfer-UI/issues/3

Added to the if condition that checks whether the system runs on MAC OS (sys.platform == "darwin") the check if cuda is available. If the system runs on MAC OS or cuda is not available, the OpenGL version will be 4.1. Else the OpenGL version will be 4.5

For testing, I added a print statement that prints your GL version when you run the viewer. If you do not have cuda (you have to install the GPU-version of pytorch for that), it should print (4,1). If you have a device with cuda support and the GPU-version of PyTorch installed, it should print (4,5).