### PR TITLE
Added keyframes to functionality 

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -247,8 +247,16 @@ class SMPLSequence(Node):
         i_left_hand_end = i_body_end + smpl_layer.bm.NUM_HAND_JOINTS * 3
         i_right_hand_end = i_left_hand_end + smpl_layer.bm.NUM_HAND_JOINTS * 3
 
+
         print(poses[:, i_body_end:i_left_hand_end].shape)
         print(smpl_layer.bm.NUM_HAND_JOINTS * 3)
+
+
+        keyframes_data = np.load(npz_data_path.replace("motion", "keyframes"))
+        print(list(keyframes_data.keys()))
+        #print(keyframes_data["indices"])
+        #print(keyframes_data["joints"])
+
 
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -183,7 +183,7 @@ class SMPLSequence(Node):
         if self._z_up and not C.z_up:
             self.rotation = np.matmul(np.array([[1, 0, 0], [0, 0, 1], [0, -1, 0]]), self.rotation)
 
-        if self.smpl_layer.model_type != "mano":
+        if self.smpl_layer.model_type != "mano": # self.smpl_layer.model_type != "smplh"
             self.rbs = RigidBodies(self.joints, global_oris, length=0.1, gui_affine=False, name="Joint Angles")
             self._add_node(self.rbs, enabled=self._show_joint_angles)
 
@@ -254,8 +254,9 @@ class SMPLSequence(Node):
 
         keyframes_data = np.load(npz_data_path.replace("motion", "keyframes"))
         print(list(keyframes_data.keys()))
-        #print(keyframes_data["indices"])
-        #print(keyframes_data["joints"])
+        # print(keyframes_data["indices"])
+        # print(keyframes_data["joints"].shape) for dimension
+        # print(keyframes_data["joints"])
 
 
         return cls(
@@ -496,7 +497,7 @@ class SMPLSequence(Node):
 
         skeleton = (
             self.smpl_layer.skeletons()["body"].T
-            if not self.smpl_layer.model_type == "mano"
+            if not self.smpl_layer.model_type == "mano" # and not self.smpl_layer.model_type == "smplh"
             else self.smpl_layer.skeletons()["all"].T
         )
         faces = self.smpl_layer.bm.faces.astype(np.int64)

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -365,7 +365,6 @@ class SMPLSequence(Node):
 # this export function saves a motion in the AMASS format, where there is only one poses array
     def export_to_AMASS(self, file: Union[IO, str]):
 
-
         np.savez(
             file + "_motion.npz",
             poses=c2c(self.posesWHands),
@@ -384,7 +383,7 @@ class SMPLSequence(Node):
             joints=c2c(self.keyframes_joints),
            )
         
-        self.keyframes_indices=np.array([])
+        self.keyframes_indices=np.array([], dtype = int)
         self.keyframes_joints=np.array([])
 
     @property

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -232,7 +232,7 @@ class SMPLSequence(Node):
         poses = body_data["poses"][sf:ef]
         trans = body_data["trans"][sf:ef]
 
-        print(body_data["mocap_framerate"])
+
 
         if fps_out is not None:
             fps_in = body_data["mocap_framerate"].tolist()
@@ -246,6 +246,9 @@ class SMPLSequence(Node):
         i_body_end = i_root_end + smpl_layer.bm.NUM_BODY_JOINTS * 3
         i_left_hand_end = i_body_end + smpl_layer.bm.NUM_HAND_JOINTS * 3
         i_right_hand_end = i_left_hand_end + smpl_layer.bm.NUM_HAND_JOINTS * 3
+
+        print(poses[:, i_body_end:i_left_hand_end].shape)
+        print(smpl_layer.bm.NUM_HAND_JOINTS * 3)
 
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],
@@ -353,13 +356,15 @@ class SMPLSequence(Node):
 
 # this export function saves a motion in the AMASS format, where there is only one poses array
     def export_to_AMASS(self, file: Union[IO, str]):
+
+
         np.savez(
             file + "_motion.npz",
-            poses=c2c(self.poses),
+            poses=c2c(self.posesWHands),
             trans=c2c(self.trans),
             betas=c2c(self.betas[0]),
-            mocap_framerate=c2c(60.0), # could change?
-            gender=c2c(np.array(self.smpl_layer.bm.gender)), # "female" # how to get this??
+            mocap_framerate=60.0, # could change?
+            gender=c2c(np.array(self.smpl_layer.bm.gender)),
         )
          
         self.keyframes_indices = np.unique(self.keyframes_indices)
@@ -397,6 +402,10 @@ class SMPLSequence(Node):
     @property
     def poses(self):
         return torch.cat((self.poses_root, self.poses_body), dim=-1)
+    
+    @property
+    def posesWHands(self):
+        return torch.cat((self.poses_root, self.poses_body, self.poses_left_hand, self.poses_right_hand), dim=-1)
 
     @property
     def _edit_mode(self):

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -753,7 +753,8 @@ class SMPLSequence(Node):
             os.makedirs(dir, exist_ok=True)
             path = os.path.join(dir, self.name)
             self.export_to_AMASS(path)
-            print(f'Exported AMASS sequence to "{path}"')
+            print(f'Exported AMASS sequence to "{path}_motion.npz"')
+            print(f'Exported keyframes to "{path}_keyframes.npz"')
 
     def gui_context_menu(self, imgui, x: int, y: int):
         if self.edit_mode and self._edit_joint is not None:

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -373,9 +373,21 @@ class SMPLSequence(Node):
             mocap_framerate=60.0, # could change?
             gender=c2c(np.array(self.smpl_layer.bm.gender)),
         )
+
+        verts, all_joints = self.smpl_layer(
+                poses_root=self.poses_root,
+                poses_body=self.poses_body,
+                poses_left_hand=self.poses_left_hand,
+                poses_right_hand=self.poses_right_hand,
+                betas=self.betas,
+                trans=self.trans,
+            )
+        
+        whole_skeleton = self.smpl_layer.skeletons()["all"].T
+        all_joints = all_joints[:, : whole_skeleton.shape[0]]
          
         self.keyframes_indices = np.unique(self.keyframes_indices)
-        self.keyframes_joints = self.joints[self.keyframes_indices]
+        self.keyframes_joints = all_joints[self.keyframes_indices]
 
         np.savez(
             file + "_keyframes.npz",
@@ -383,8 +395,10 @@ class SMPLSequence(Node):
             joints=c2c(self.keyframes_joints),
            )
         
-        self.keyframes_indices=np.array([], dtype = int)
+        self.keyframes_indices=np.array([], dtype=int)
         self.keyframes_joints=np.array([])
+
+
 
     @property
     def color(self):

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -51,7 +51,7 @@ class SMPLSequence(Node):
         z_up=False,
         post_fk_func=None,
         icon="\u0093",
-        keyframes=np.empty,
+        keyframes=np.array([]),
         **kwargs,
     ):
         """
@@ -345,7 +345,7 @@ class SMPLSequence(Node):
             trans=c2c(self.trans),
             keyframes=c2c(self.keyframes),
         )
-        self.keyframes=np.empty
+        self.keyframes=np.array([])
 
     @property
     def color(self):
@@ -690,6 +690,7 @@ class SMPLSequence(Node):
             self._edit_pose_dirty = False
             self.redraw(current_frame_only=True)
             self.keyframes = np.append(self.keyframes, self.current_frame_id)
+            self.keyframes = np.unique(self.keyframes)
         imgui.same_line()
         if imgui.button("Apply to all"):
             edit_rots = Rotation.from_rotvec(np.reshape(self._edit_pose.cpu().numpy(), (-1, 3)))

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     # We set transparency to 0.5 and render the joint coordinates systems.
     c = (149 / 255, 85 / 255, 149 / 255, 0.5)
     seq_amass = SMPLSequence.from_amass(
-        npz_data_path=os.path.join(C.datasets.amass, "ACCAD/Female1Running_c3d/C2 - Run to stand_poses.npz"),
+        npz_data_path=os.path.join(C.datasets.amass, "ACCAD/Female1Running_c3d/AMASS Running_motion.npz"),  # AMASS Running_motion.npz #C2 - Run to stand_poses.npz
         fps_out=60.0,
         color=c,
         name="AMASS Running",

--- a/examples/load_export_AMASS.py
+++ b/examples/load_export_AMASS.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023  ETH Zurich, Manuel Kaufmann, Velko Vechev, Dario Mylonopoulos
+import os
+import numpy as np
+from aitviewer.configuration import CONFIG as C
+from aitviewer.renderables.point_clouds import PointClouds
+
+from aitviewer.renderables.smpl import SMPLSequence
+from aitviewer.viewer import Viewer
+
+
+v = Viewer()
+v.scene.camera.position = np.array([10.0, 2.5, 0.0])
+seq_export = SMPLSequence.from_npz(file=os.path.join(C.export_dir, "SMPL/AMASS Running.npz"), z_up=True)
+ptc_export = PointClouds(seq_export.vertices, position=np.array([1.0, 0.0, 0.0]), z_up=True)
+v.scene.add(seq_export, ptc_export)
+v.run()


### PR DESCRIPTION
Resolves https://github.com/luni1024/Style-Transfer-UI/issues/6
- Added keyframes-Array to save the changed keyframes
- Keyframes will be saved separately when pressing "Apply"
- When an npz file is executed with load_export_AMASS.py, there is now an additional output of the keyframes array which states which frames have been changed but this is only important for testing
- After the export, keyframes is emptied