### PR TITLE
Issue13

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -160,6 +160,7 @@ class SMPLSequence(Node):
                 color=(1.0, 177 / 255, 1 / 255, 1.0),
                 name="Skeleton",
             )
+            self.skeleton_default_color = self.skeleton_seq.color
             self._add_node(self.skeleton_seq)
 
         # First convert the relative joint angles to global joint angles in rotation matrix form.
@@ -195,6 +196,7 @@ class SMPLSequence(Node):
             color=kwargs.get("color", (160 / 255, 160 / 255, 160 / 255, 1.0)),
             name="Mesh",
         )
+        self.mesh_default_color = self.mesh_seq.color
         self._add_node(self.mesh_seq)
 
         # Save view mode state to restore when exiting edit mode.

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -253,12 +253,16 @@ class SMPLSequence(Node):
         print(poses[:, i_body_end:i_left_hand_end].shape)
         print(smpl_layer.bm.NUM_HAND_JOINTS * 3)
 
-
-        keyframes_data = np.load(npz_data_path.replace("motion", "keyframes"))
-        print(list(keyframes_data.keys()))
-        # print(keyframes_data["indices"])
-        # print(keyframes_data["joints"].shape) for dimension
-        # print(keyframes_data["joints"])
+        try:
+            keyframes_data = np.load(npz_data_path.replace("motion", "keyframes"))
+            keyframes_indices=keyframes_data["indices"]
+            print(list(keyframes_data.keys()))
+            # print(keyframes_data["indices"])
+            # print(keyframes_data["joints"].shape) for dimension
+            # print(keyframes_data["joints"])
+        except:
+            keyframes_indices=np.array([],dtype=int)
+            print("No keyframes file")
 
 
         return cls(
@@ -270,6 +274,7 @@ class SMPLSequence(Node):
             betas=body_data["betas"][np.newaxis],
             trans=trans,
             z_up=z_up,
+            keyframes_indices=keyframes_indices,
             **kwargs,
         )
 

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -539,6 +539,14 @@ class Viewer(moderngl_window.WindowConfig):
                 self.scene.current_frame_id = (self.scene.current_frame_id + frames) % self.scene.n_frames
                 self._last_frame_rendered_at += frames * (1.0 / self.playback_fps)
 
+        seq_amass = self.scene.get_node_by_uid(1)
+        if self.scene.current_frame_id in seq_amass.keyframes_indices:
+            seq_amass.skeleton_seq.color = (0, 255, 0 , 1)
+            seq_amass.mesh_seq.color = (0, 255, 0 , 0.5)
+        else:
+            seq_amass.skeleton_seq.color = seq_amass.skeleton_default_color
+            seq_amass.mesh_seq.color = seq_amass.mesh_default_color
+
         # Update camera matrices that will be used for rendering
         if isinstance(self.scene.camera, ViewerCamera):
             self.scene.camera.update_animation(frame_time)


### PR DESCRIPTION
Resolves #13 

In the aitviewer UI the keyframes of a sequence now get highlighted in the color green.
Additionally, if an amass file ending in "_motion.npz" is loaded, the `keyframes_indices` in the corresponding "_keyframes.npz" file are kept in the sequence. We might add a way to empty the `keyframes_indices` from within the UI later.

Files changed: `aitviewer/renderables/smpl.py`, `aitiviewer/viewer.py`