### PR TITLE
Issue23

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -55,7 +55,6 @@ class SMPLSequence(Node):
         keyframes_indices=np.array([], dtype=int),
         keyframes_joints=np.array([]),
         annotations=None,
-        prompt=None,
         **kwargs,
     ):
         """
@@ -208,9 +207,19 @@ class SMPLSequence(Node):
 
         # Prompt mode
         self.gui_modes.update({"prompt": {"title": " Prompts", "fn": self.gui_mode_prompt, "icon": "#"}})
-        self.prompt = prompt if prompt is not None else {'inputted': False, 'value': None, 'start': {'changed': False,'value': 0.0}, 'end': {'changed': False,'value': 0.0}}
+#        self.prompt = prompt if prompt is not None else {'inputted': False, 'value': None, 'start': {'changed': False,'value': 0.0}, 'end': {'changed': False,'value': 0.0}}
+        
+        #TODO: implement the prompt-variables as parameter-less class-variables!!!!
+        self.prompt_changed=False           #self.prompt = prompt if prompt is not None else {'inputted': False, 'value': None, 'start': {'changed': False,'value': 0.0}, 'end': {'changed': False,'value': 0.0}}
+        self.prompt_text=None
+        self.prompt_start_changed=False
+        self.prompt_start_value=0
+        self.prompt_end_changed=False
+        self.prompt_end_value=(self.n_frames - 1)/60
 
-        self.annotations = list(annotations) if annotations is not None else []
+        self.current_prompts_only=False
+        
+        self.annotations = annotations if annotations is not None else []
 
     @classmethod
     def from_amass(
@@ -222,12 +231,11 @@ class SMPLSequence(Node):
         log=True,
         fps_out=None,
         z_up=True,
-        annotations=None,
         **kwargs,
     ):
         """Load a sequence downloaded from the AMASS website."""
 
-        body_data = np.load(npz_data_path, allow_pickle=True)
+        body_data = np.load(npz_data_path)
         if smpl_layer is None:
             smpl_layer = SMPLLayer(model_type="smplh", gender=body_data["gender"].item(), device=C.device)
 
@@ -265,8 +273,6 @@ class SMPLSequence(Node):
         keyframes_indices = body_data.get("keyframes_indices", np.array([], dtype=int))
         original_poses = body_data.get("original_poses", None)
 
-        annotations = body_data.get("annotations", annotations) 
-
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],
             poses_root=poses[:, :i_root_end],
@@ -278,7 +284,6 @@ class SMPLSequence(Node):
             z_up=z_up,
             keyframes_indices=keyframes_indices,
             original_poses=original_poses,
-            annotations=annotations,
             **kwargs,
         )
 
@@ -375,8 +380,8 @@ class SMPLSequence(Node):
         )
         self.keyframes_indices=np.array([], dtype=int)
 
+# this export function saves a motion in the AMASS format, where there is only one poses array
     def export_to_AMASS(self, file: Union[IO, str]):
-        '''Exports the motion to a .npz file in the AMASS format (containing only one poses array).'''
         verts, all_joints = self.smpl_layer(
                 poses_root=self.poses_root,
                 poses_body=self.poses_body,
@@ -403,7 +408,6 @@ class SMPLSequence(Node):
             gender=c2c(np.array(self.smpl_layer.bm.gender)),
             keyframes_indices=c2c(self.keyframes_indices),
             keyframes_joints=c2c(self.keyframes_joints),
-            annotations=c2c(np.array(self.annotations)),
         )
         
         self.keyframes_indices=np.array([], dtype=int)
@@ -786,35 +790,55 @@ class SMPLSequence(Node):
         second = self.current_frame_id / 60
         first_index = len(self.annotations)
         sorted_annotations = sorted(self.annotations, key=lambda elem: elem["start"])
+#        current_annotations = filter(sorted_annotations, lambda )
 
+
+        _, self.current_prompts_only = imgui.checkbox("Show only current prompts", self.current_prompts_only)
         for i, annotation in enumerate(sorted_annotations):
-            if i > first_index:
-                if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
-                    imgui.text_wrapped(annotation["text"])
-                    if imgui.button("Delete"):
-                        self.annotations.remove(annotation)
-                    imgui.tree_pop()
+            if self.current_prompts_only:
+                if annotation["start"] <= second and annotation["end"] >= second:
+                    if i > first_index:
+                        if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
+                            imgui.text_wrapped(annotation["text"])
+                            if imgui.button("Delete"):
+                                self.annotations.remove(annotation)
+                            imgui.tree_pop()
+                    else:
+                        if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):      # This part is for the first Prompt, which gets a different Formatting
+                            imgui.text_wrapped(annotation["text"])
+                            if imgui.button("Delete"):
+                                self.annotations.remove(annotation)
+                            imgui.tree_pop()
+                        first_index = i
             else:
-                if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):      # This part is for the first Prompt, which gets a different Formatting
-                    imgui.text_wrapped(annotation["text"])
-                    if imgui.button("Delete"):
-                        self.annotations.remove(annotation)
-                    imgui.tree_pop()
-                first_index = i
+                if i != 0:
+                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
+                        imgui.text_wrapped(annotation["text"])
+                        if imgui.button("Delete"):
+                            self.annotations.remove(annotation)
+                        imgui.tree_pop()
+                else:
+                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):      # This part is for the first Prompt, which gets a different Formatting
+                        imgui.text_wrapped(annotation["text"])
+                        if imgui.button("Delete"):
+                            self.annotations.remove(annotation)
+                        imgui.tree_pop()
+
+        imgui.dummy(0, 5)
 
 
         ## Add-Button & Start/End Sliders:
         
-        default = self.prompt['value'] if self.prompt['value'] is not None else 'Enter Prompt:'
-        
+        default = self.prompt_text if self.prompt_text is not None else 'Enter Prompt:'
+
         # Prompt_input_field
         text_input_changed, Prompt = imgui.input_text("", default)
         
         # Slidervariables
-        start_val = self.prompt['start']['value']
-        end_val = self.prompt['end']['value']
-        start_changed = self.prompt['start']['changed']
-        end_changed = self.prompt['end']['changed']
+        start_val = self.prompt_start_value
+        end_val = self.prompt_end_value
+        start_changed = self.prompt_start_changed
+        end_changed = self.prompt_end_changed
         if start_changed:
             end_val = max(start_val, end_val)
         if end_changed:
@@ -822,33 +846,35 @@ class SMPLSequence(Node):
 
         # Updating the Prompt(-Input)
         if text_input_changed:
-            self.prompt['inputted'] = True
-            self.prompt['value'] = Prompt
+            self.prompt_changed = True
+            self.prompt_text = Prompt
 
         # Add-Button
         Enter_pressed = imgui.is_key_pressed(imgui.KEY_ENTER)
         imgui.same_line()
-        if (imgui.button("Add") or Enter_pressed) and self.prompt['inputted']:
-            self.annotations.append({'seg_id': 'user', 'text': self.prompt['value'], 'start': round(self.prompt['start']['value'], 3), 'end': round(self.prompt['end']['value'], 3)})
-            self.prompt['inputted'] = False
-            self.prompt['value'] = None
+        if (imgui.button("Add") or Enter_pressed) and self.prompt_changed:
+            self.annotations.append({'seg_id': 'user', 'text': self.prompt_text, 'start': round(self.prompt_start_value, 3), 'end': round(self.prompt_end_value, 3)})
+            self.prompt_changed = False
+            self.prompt_text = None
 
         # Sliders
-        self.prompt['start']['changed'], self.prompt['start']['value'] = imgui.slider_float(f'Start',
+        self.prompt_start_changed, self.prompt_start_value = imgui.slider_float(f'Start',
                            start_val,
                            min_value=0,
                            max_value=(self.n_frames - 1)/60)
 
-        self.prompt['end']['changed'], self.prompt['end']['value'] = imgui.slider_float(f'End',
+        self.prompt_end_changed, self.prompt_end_value = imgui.slider_float(f'End',
                            end_val,
                            min_value=0,
                            max_value=(self.n_frames - 1)/60)
+
+        imgui.dummy(0, 5)
 
         imgui.slider_float(
                 "Second##r_{}".format(self.unique_name),
                 second,
                 min_value=0,
-                max_value=(self.n_frames - 1)/60,)
+                max_value=(self.n_frames - 1)/60)
 
     def gui_io(self, imgui):
         # uses export_to_AMASS now

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -55,6 +55,8 @@ class SMPLSequence(Node):
         keyframes_indices=np.array([], dtype=int),
         keyframes_joints=np.array([]),
         annotations=None,
+        prompt_given=False,
+        prompt_input=None,
         **kwargs,
     ):
         """
@@ -800,13 +802,15 @@ class SMPLSequence(Node):
                     imgui.tree_pop()
                 first_index = i
 
-        Add_pressed = imgui.button("Add")
+        text_input_changed, Prompt = imgui.input_text("", 'Enter Prompt:')
+        if text_input_changed:
+            self.prompt_inputted = True
+            self.prompt_input = Prompt
         imgui.same_line()
-        text_changed, Prompt = imgui.input_text("", "Enter Prompt:")
-        if text_changed and Add_pressed:
-            annotation = {'seg_id': 'user', 'text': Prompt, 'start': round(second, 3), 'end': round((second + 0.5), 3)}
-            self.annotations.append(annotation)
-
+        if imgui.button("Add") and self.prompt_inputted:
+            self.annotations.append({'seg_id': 'user', 'text': self.prompt_input, 'start': round(second, 3), 'end': round(second + 0.5, 3)})
+        
+        
         imgui.slider_float(
                 "Second##r_{}".format(self.unique_name),
                 second,

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -54,7 +54,7 @@ class SMPLSequence(Node):
         original_poses=None,
         keyframes_indices=np.array([], dtype=int),
         keyframes_joints=np.array([]),
-        annotation=None,
+        annotations=None,
         **kwargs,
     ):
         """
@@ -205,7 +205,10 @@ class SMPLSequence(Node):
         self._view_mode_color = self.mesh_seq.color
         self._view_mode_joint_angles = self._show_joint_angles
 
-        self.annotation = annotation
+        # Prompt mode
+        self.gui_modes.update({"prompt": {"title": " Prompts", "fn": self.gui_mode_prompt, "icon": "#"}})
+
+        self.annotations = annotations
 
     @classmethod
     def from_amass(
@@ -726,14 +729,6 @@ class SMPLSequence(Node):
                     self._gui_joint(imgui, c, tree)
                 imgui.tree_pop()
 
-    def gui_stats(self, imgui):
-        if self.annotation is not None:
-            imgui.text("Annotation: ")
-            imgui.same_line()
-            imgui.input_text("", self.annotation)
-        super().gui_stats(imgui)
-
-
     def gui_mode_edit(self, imgui):
         skel = self.smpl_layer.skeletons()["body"].cpu().numpy()
 
@@ -776,9 +771,35 @@ class SMPLSequence(Node):
             self._edit_pose_dirty = False
             self.redraw(current_frame_only=True)
 
+
     def gui_stats(self,imgui):
         super().gui_stats(imgui)
         imgui.text_wrapped(f"Keyframes: {np.unique(self.keyframes_indices)}")
+
+    def gui_mode_prompt(self, imgui):
+        if self.annotations is not None:
+            second = self.current_frame_id / 60
+            first_index = len(self.annotations)
+            for i, annotation in enumerate(self.annotations):
+                if annotation["start"] <= second and annotation["end"] >= second:
+                    if i > first_index:
+                        if(imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}')):
+                            imgui.text(annotation["text"])
+                            imgui.tree_pop()
+                    else:
+                        #imgui.input_text("", annotation["text"])
+                        imgui.push_font(None)
+                        imgui.text(f'Main Prompt: {annotation["text"]}')
+                        imgui.pop_font()
+                        first_index = i
+
+
+        imgui.slider_float(
+                "Second##r_{}".format(self.unique_name),
+                second,
+                min_value=0,
+                max_value=(self.n_frames - 1)/60,)
+
 
     def gui_io(self, imgui):
         # uses export_to_AMASS now

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -208,7 +208,7 @@ class SMPLSequence(Node):
         # Prompt mode
         self.gui_modes.update({"prompt": {"title": " Prompts", "fn": self.gui_mode_prompt, "icon": "#"}})
 
-        self.annotations = annotations
+        self.annotations = annotations if annotations is not None else []
 
     @classmethod
     def from_amass(
@@ -777,22 +777,27 @@ class SMPLSequence(Node):
         imgui.text_wrapped(f"Keyframes: {np.unique(self.keyframes_indices)}")
 
     def gui_mode_prompt(self, imgui):
-        if self.annotations is not None:
-            second = self.current_frame_id / 60
-            first_index = len(self.annotations)
-            for i, annotation in enumerate(self.annotations):
-                if annotation["start"] <= second and annotation["end"] >= second:
-                    if i > first_index:
-                        if(imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}')):
-                            imgui.text(annotation["text"])
-                            imgui.tree_pop()
-                    else:
-                        #imgui.input_text("", annotation["text"])
-                        imgui.push_font(None)
-                        imgui.text(f'Main Prompt: {annotation["text"]}')
-                        imgui.pop_font()
-                        first_index = i
+        second = self.current_frame_id / 60
+        first_index = len(self.annotations)
+        for i, annotation in enumerate(self.annotations):
+            if annotation["start"] <= second and annotation["end"] >= second:
+                if i > first_index:
+                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
+                        imgui.text_wrapped(annotation["text"])
+                        if imgui.button("Delete"):
+                            pass
+                        imgui.tree_pop()
+                else:
+                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):
+                        imgui.text_wrapped(annotation["text"])
+                        if imgui.button("Delete"):
+                            pass
+                        imgui.tree_pop()
+                    first_index = i
 
+        if imgui.button("Add"):
+            #imgui.input_text("", annotation["text"])
+            pass
 
         imgui.slider_float(
                 "Second##r_{}".format(self.unique_name),

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -729,6 +729,14 @@ class SMPLSequence(Node):
                     self._gui_joint(imgui, c, tree)
                 imgui.tree_pop()
 
+    def gui_stats(self, imgui):
+        if self.annotation is not None:
+            imgui.text("Annotation: ")
+            imgui.same_line()
+            imgui.input_text("", self.annotation)
+        super().gui_stats(imgui)
+
+
     def gui_mode_edit(self, imgui):
         skel = self.smpl_layer.skeletons()["body"].cpu().numpy()
 

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -398,7 +398,7 @@ class SMPLSequence(Node):
             gender=c2c(np.array(self.smpl_layer.bm.gender)),
             keyframes_indices=c2c(self.keyframes_indices),
             keyframes_joints=c2c(self.keyframes_joints),
-            annotations=c2c(self.annotations),
+            annotations=c2c(np.array(self.annotations)),
         )
         
         self.keyframes_indices=np.array([], dtype=int)

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -783,25 +783,29 @@ class SMPLSequence(Node):
     def gui_mode_prompt(self, imgui):
         second = self.current_frame_id / 60
         first_index = len(self.annotations)
-        for i, annotation in enumerate(self.annotations):
-            if annotation["start"] <= second and annotation["end"] >= second:
-                if i > first_index:
-                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
-                        imgui.text_wrapped(annotation["text"])
-                        if imgui.button("Delete"):
-                            pass
-                        imgui.tree_pop()
-                else:
-                    if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):
-                        imgui.text_wrapped(annotation["text"])
-                        if imgui.button("Delete"):
-                            pass
-                        imgui.tree_pop()
-                    first_index = i
+        sorted_annotations = sorted(self.annotations, key=lambda elem: elem["start"])
 
-        if imgui.button("Add"):
-            #imgui.input_text("", annotation["text"])
-            pass
+        for i, annotation in enumerate(sorted_annotations):
+            if i > first_index:
+                if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}'):
+                    imgui.text_wrapped(annotation["text"])
+                    if imgui.button("Delete"):
+                        self.annotations.remove(annotation)
+                    imgui.tree_pop()
+            else:
+                if imgui.tree_node(f'Prompt {i}: {annotation["start"]} - {annotation["end"]}', flags=imgui.TREE_NODE_DEFAULT_OPEN|imgui.TREE_NODE_FRAMED):      # This part is for the first Prompt, which gets a different Formatting
+                    imgui.text_wrapped(annotation["text"])
+                    if imgui.button("Delete"):
+                        self.annotations.remove(annotation)
+                    imgui.tree_pop()
+                first_index = i
+
+        Add_pressed = imgui.button("Add")
+        imgui.same_line()
+        text_changed, Prompt = imgui.input_text("", "Enter Prompt:")
+        if text_changed and Add_pressed:
+            annotation = {'seg_id': 'user', 'text': Prompt, 'start': round(second, 3), 'end': round((second + 0.5), 3)}
+            self.annotations.append(annotation)
 
         imgui.slider_float(
                 "Second##r_{}".format(self.unique_name),

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -224,7 +224,7 @@ class SMPLSequence(Node):
     ):
         """Load a sequence downloaded from the AMASS website."""
 
-        body_data = np.load(npz_data_path)
+        body_data = np.load(npz_data_path, allow_pickle=True)
         if smpl_layer is None:
             smpl_layer = SMPLLayer(model_type="smplh", gender=body_data["gender"].item(), device=C.device)
 

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -55,8 +55,7 @@ class SMPLSequence(Node):
         keyframes_indices=np.array([], dtype=int),
         keyframes_joints=np.array([]),
         annotations=None,
-        prompt_given=False,
-        prompt_input=None,
+        prompt=None,
         **kwargs,
     ):
         """
@@ -209,6 +208,7 @@ class SMPLSequence(Node):
 
         # Prompt mode
         self.gui_modes.update({"prompt": {"title": " Prompts", "fn": self.gui_mode_prompt, "icon": "#"}})
+        self.prompt = prompt if prompt is not None else {'inputted': False, 'value': None, 'start': {'changed': False,'value': 0.0}, 'end': {'changed': False,'value': 0.0}}
 
         self.annotations = list(annotations) if annotations is not None else []
 
@@ -802,15 +802,48 @@ class SMPLSequence(Node):
                     imgui.tree_pop()
                 first_index = i
 
-        text_input_changed, Prompt = imgui.input_text("", 'Enter Prompt:')
+
+        ## Add-Button & Start/End Sliders:
+        
+        default = self.prompt['value'] if self.prompt['value'] is not None else 'Enter Prompt:'
+        
+        # Prompt_input_field
+        text_input_changed, Prompt = imgui.input_text("", default)
+        
+        # Slidervariables
+        start_val = self.prompt['start']['value']
+        end_val = self.prompt['end']['value']
+        start_changed = self.prompt['start']['changed']
+        end_changed = self.prompt['end']['changed']
+        if start_changed:
+            end_val = max(start_val, end_val)
+        if end_changed:
+            start_val = min(start_val, end_val)
+
+        # Updating the Prompt(-Input)
         if text_input_changed:
-            self.prompt_inputted = True
-            self.prompt_input = Prompt
+            self.prompt['inputted'] = True
+            self.prompt['value'] = Prompt
+
+        # Add-Button
+        Enter_pressed = imgui.is_key_pressed(imgui.KEY_ENTER)
         imgui.same_line()
-        if imgui.button("Add") and self.prompt_inputted:
-            self.annotations.append({'seg_id': 'user', 'text': self.prompt_input, 'start': round(second, 3), 'end': round(second + 0.5, 3)})
-        
-        
+        if (imgui.button("Add") or Enter_pressed) and self.prompt['inputted']:
+            self.annotations.append({'seg_id': 'user', 'text': self.prompt['value'], 'start': round(self.prompt['start']['value'], 3), 'end': round(self.prompt['end']['value'], 3)})
+            self.prompt['inputted'] = False
+            self.prompt['value'] = None
+
+        # Sliders
+        self.prompt['start']['changed'], self.prompt['start']['value'] = imgui.slider_float(f'Start',
+                           start_val,
+                           min_value=0,
+                           max_value=(self.n_frames - 1)/60)
+
+        self.prompt['end']['changed'], self.prompt['end']['value'] = imgui.slider_float(f'End',
+                           end_val,
+                           min_value=0,
+                           max_value=(self.n_frames - 1)/60)
+
         imgui.slider_float(
                 "Second##r_{}".format(self.unique_name),
                 second,

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -54,6 +54,7 @@ class SMPLSequence(Node):
         original_poses=None,
         keyframes_indices=np.array([], dtype=int),
         keyframes_joints=np.array([]),
+        annotation=None,
         **kwargs,
     ):
         """
@@ -203,6 +204,8 @@ class SMPLSequence(Node):
         # Save view mode state to restore when exiting edit mode.
         self._view_mode_color = self.mesh_seq.color
         self._view_mode_joint_angles = self._show_joint_angles
+
+        self.annotation = annotation
 
     @classmethod
     def from_amass(
@@ -722,6 +725,14 @@ class SMPLSequence(Node):
                 for c in tree.get(j, []):
                     self._gui_joint(imgui, c, tree)
                 imgui.tree_pop()
+
+    def gui_stats(self, imgui):
+        if self.annotation is not None:
+            imgui.text("Annotation: ")
+            imgui.same_line()
+            imgui.input_text("", self.annotation)
+        super().gui_stats(imgui)
+
 
     def gui_mode_edit(self, imgui):
         skel = self.smpl_layer.skeletons()["body"].cpu().numpy()

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -370,8 +370,8 @@ class SMPLSequence(Node):
         )
         self.keyframes_indices=np.array([], dtype=int)
 
-# this export function saves a motion in the AMASS format, where there is only one poses array
     def export_to_AMASS(self, file: Union[IO, str]):
+        '''Exports the motion to a .npz file in the AMASS format (containing only one poses array).'''
         verts, all_joints = self.smpl_layer(
                 poses_root=self.poses_root,
                 poses_body=self.poses_body,
@@ -398,6 +398,7 @@ class SMPLSequence(Node):
             gender=c2c(np.array(self.smpl_layer.bm.gender)),
             keyframes_indices=c2c(self.keyframes_indices),
             keyframes_joints=c2c(self.keyframes_joints),
+            annotations=c2c(self.annotations),
         )
         
         self.keyframes_indices=np.array([], dtype=int)

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -263,7 +263,7 @@ class SMPLSequence(Node):
         keyframes_indices = body_data.get("keyframes_indices", np.array([], dtype=int))
         original_poses = body_data.get("original_poses", None)
 
-        annotations = body_data.get("annotations", None) 
+        annotations = body_data.get("annotations", annotations) 
 
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -208,7 +208,7 @@ class SMPLSequence(Node):
         # Prompt mode
         self.gui_modes.update({"prompt": {"title": " Prompts", "fn": self.gui_mode_prompt, "icon": "#"}})
 
-        self.annotations = annotations if annotations is not None else []
+        self.annotations = list(annotations) if annotations is not None else []
 
     @classmethod
     def from_amass(
@@ -220,6 +220,7 @@ class SMPLSequence(Node):
         log=True,
         fps_out=None,
         z_up=True,
+        annotations=None,
         **kwargs,
     ):
         """Load a sequence downloaded from the AMASS website."""
@@ -261,7 +262,8 @@ class SMPLSequence(Node):
 
         keyframes_indices = body_data.get("keyframes_indices", np.array([], dtype=int))
         original_poses = body_data.get("original_poses", None)
-        annotations = body_data.get("annotations", None)
+
+        annotations = body_data.get("annotations", None) 
 
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],
@@ -274,6 +276,7 @@ class SMPLSequence(Node):
             z_up=z_up,
             keyframes_indices=keyframes_indices,
             original_poses=original_poses,
+            annotations=annotations,
             **kwargs,
         )
 

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -729,14 +729,6 @@ class SMPLSequence(Node):
                     self._gui_joint(imgui, c, tree)
                 imgui.tree_pop()
 
-    def gui_stats(self, imgui):
-        if self.annotation is not None:
-            imgui.text("Annotation: ")
-            imgui.same_line()
-            imgui.input_text("", self.annotation)
-        super().gui_stats(imgui)
-
-
     def gui_mode_edit(self, imgui):
         skel = self.smpl_layer.skeletons()["body"].cpu().numpy()
 
@@ -779,7 +771,6 @@ class SMPLSequence(Node):
             self._edit_pose_dirty = False
             self.redraw(current_frame_only=True)
 
-
     def gui_stats(self,imgui):
         super().gui_stats(imgui)
         imgui.text_wrapped(f"Keyframes: {np.unique(self.keyframes_indices)}")
@@ -812,7 +803,6 @@ class SMPLSequence(Node):
                 second,
                 min_value=0,
                 max_value=(self.n_frames - 1)/60,)
-
 
     def gui_io(self, imgui):
         # uses export_to_AMASS now

--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -261,6 +261,7 @@ class SMPLSequence(Node):
 
         keyframes_indices = body_data.get("keyframes_indices", np.array([], dtype=int))
         original_poses = body_data.get("original_poses", None)
+        annotations = body_data.get("annotations", None)
 
         return cls(
             poses_body=poses[:, i_root_end:i_body_end],

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -17,8 +17,8 @@ if __name__ == "__main__":
 
     with open("../babel_humanml3d_kitml_ori.json") as json_data:
         prompts = json.load(json_data)
-        seq_prompt = prompts[path[:-4]] # :-4 removes the .npz from the path
-        annotations = seq_prompt["annotations"]
+        seq_prompt = prompts.get(path[:-4]) # :-4 removes the .npz from the path
+        annotations = None if seq_prompt is None else seq_prompt["annotations"]
 
     seq_amass = SMPLSequence.from_amass(
         npz_data_path=os.path.join(C.datasets.amass, path),  # AMASS Running_motion.npz #Female1Running_c3d/C2 - Run to stand_poses.npz #AMASS Stand_poses (2 close frames)_motion

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -12,16 +12,13 @@ from aitviewer.viewer import Viewer
 if __name__ == "__main__":
     # Load an AMASS sequence and make sure it's sampled at 60 fps. This automatically loads the SMPL-H model.
     # We set transparency to 0.5 and render the joint coordinates systems.
-    path = "ACCAD/Female1Running_c3d/C2 - Run to stand_poses.npz"
+    path = "ACCAD/Female1Running_c3d/C20 -  run to jump to walk_poses.npz"
     c = (149 / 255, 85 / 255, 149 / 255, 0.5)
 
     with open("../babel_humanml3d_kitml_ori.json") as json_data:
         prompts = json.load(json_data)
-        prompt = prompts[path[:-4]]
-        annotations = prompt["annotations"]
-        annotation0 = annotations[0]
-        annotation = annotation0["text"]
-        print(annotation)
+        seq_prompt = prompts[path[:-4]] # :-4 removes the .npz from the path
+        annotations = seq_prompt["annotations"]
 
     seq_amass = SMPLSequence.from_amass(
         npz_data_path=os.path.join(C.datasets.amass, path),  # AMASS Running_motion.npz #Female1Running_c3d/C2 - Run to stand_poses.npz #AMASS Stand_poses (2 close frames)_motion
@@ -29,7 +26,7 @@ if __name__ == "__main__":
         color=c,
         name="AMASS Running",
         show_joint_angles=True,
-        annotation=annotation,
+        annotations=annotations,
     )
 
 

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     path = "ACCAD/Female1Running_c3d/C2 - Run to stand_poses.npz"
     c = (149 / 255, 85 / 255, 149 / 255, 0.5)
 
-    with open("babel_humanml3d_kitml_ori.json") as json_data:
+    with open("../babel_humanml3d_kitml_ori.json") as json_data:
         prompts = json.load(json_data)
         prompt = prompts[path[:-4]]
         annotations = prompt["annotations"]

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -12,6 +12,7 @@ from aitviewer.viewer import Viewer
 if __name__ == "__main__":
     # Load an AMASS sequence and make sure it's sampled at 60 fps. This automatically loads the SMPL-H model.
     # We set transparency to 0.5 and render the joint coordinates systems.
+
     path = "ACCAD/Female1Running_c3d/C20 -  run to jump to walk_poses.npz"
     c = (149 / 255, 85 / 255, 149 / 255, 0.5)
 

--- a/examples/load_AMASS.py
+++ b/examples/load_AMASS.py
@@ -2,6 +2,7 @@
 import os
 
 import numpy as np
+import json
 
 from aitviewer.configuration import CONFIG as C
 from aitviewer.renderables.point_clouds import PointClouds
@@ -11,14 +12,26 @@ from aitviewer.viewer import Viewer
 if __name__ == "__main__":
     # Load an AMASS sequence and make sure it's sampled at 60 fps. This automatically loads the SMPL-H model.
     # We set transparency to 0.5 and render the joint coordinates systems.
+    path = "ACCAD/Female1Running_c3d/C2 - Run to stand_poses.npz"
     c = (149 / 255, 85 / 255, 149 / 255, 0.5)
+
+    with open("babel_humanml3d_kitml_ori.json") as json_data:
+        prompts = json.load(json_data)
+        prompt = prompts[path[:-4]]
+        annotations = prompt["annotations"]
+        annotation0 = annotations[0]
+        annotation = annotation0["text"]
+        print(annotation)
+
     seq_amass = SMPLSequence.from_amass(
-        npz_data_path=os.path.join(C.datasets.amass, "ACCAD/Female1Running_c3d/AMASS Running_motion.npz"),  # AMASS Running_motion.npz #C2 - Run to stand_poses.npz
+        npz_data_path=os.path.join(C.datasets.amass, path),  # AMASS Running_motion.npz #Female1Running_c3d/C2 - Run to stand_poses.npz #AMASS Stand_poses (2 close frames)_motion
         fps_out=60.0,
         color=c,
         name="AMASS Running",
         show_joint_angles=True,
+        annotation=annotation,
     )
+
 
     # Instead of displaying the mesh, we can also just display point clouds.
     #


### PR DESCRIPTION
Resolves #23

We want to be able to show prompts from the `babel_humanml3d_kitml_ori.json` and add prompts to a SMPL sequence.

Added a new mode for the prompts for SMPL sequences. It displays all prompts for the text duration of the sequence, also accompanied by a new slider that shows the time in seconds. The first prompt in the text duration is the Main prompt and visible during the whole text duration, every other prompt is retractable.

This is the first version for the prompt support, there might be changes in the appearance. Also some functions to add are the addition, deletion and maybe editing for prompts.