### PR TITLE
Decouple highlighting

### DIFF
--- a/aitviewer/renderables/smpl.py
+++ b/aitviewer/renderables/smpl.py
@@ -1017,3 +1017,12 @@ class SMPLSequence(Node):
 
         self.n_frames = len(self.poses_body)
         self.redraw()
+
+
+    def render(self, **kwargs):
+        if self.current_frame_id in self.keyframes_indices:
+            self.skeleton_seq.color = (0, 255, 0 , 1)
+            self.mesh_seq.color = (0, 255, 0 , 0.5)
+        else:
+            self.skeleton_seq.color = self.skeleton_seq.default_color
+            self.mesh_seq.color = self.mesh_seq.default_color

--- a/aitviewer/scene/scene.py
+++ b/aitviewer/scene/scene.py
@@ -306,20 +306,6 @@ class Scene(Node):
                 return n
         return None
 
-    def get_node_by_attribute(self, attr):
-        ns = self.collect_nodes()
-        for n in ns:
-            if hasattr(n, attr):
-                return n
-        return None
-
-    def get_node_by_class(self, type):
-        ns = self.collect_nodes()
-        for n in ns:
-            if isinstance(n, type):
-                return n
-        return None
-
     def select(self, obj, selected_node=None, selected_instance=None, selected_tri_id=None):
         """Set 'obj' as the selected object"""
         self.selected_object = obj

--- a/aitviewer/viewer.py
+++ b/aitviewer/viewer.py
@@ -542,16 +542,6 @@ class Viewer(moderngl_window.WindowConfig):
                 self.scene.current_frame_id = (self.scene.current_frame_id + frames) % self.scene.n_frames
                 self._last_frame_rendered_at += frames * (1.0 / self.playback_fps)
 
-        # SMPL type nodes have highlightable keyframes
-        seq_smpl = self.scene.get_node_by_class(SMPLSequence)
-        if seq_smpl != None:
-            if self.scene.current_frame_id in seq_smpl.keyframes_indices:
-                seq_smpl.skeleton_seq.color = (0, 255, 0 , 1)
-                seq_smpl.mesh_seq.color = (0, 255, 0 , 0.5)
-            else:
-                seq_smpl.skeleton_seq.color = seq_smpl.skeleton_seq.default_color
-                seq_smpl.mesh_seq.color = seq_smpl.mesh_seq.default_color
-
         # Update camera matrices that will be used for rendering
         if isinstance(self.scene.camera, ViewerCamera):
             self.scene.camera.update_animation(frame_time)


### PR DESCRIPTION
I defined the highlighting for the keyframes in `smpl.py` instead of `viewer.py` to make it easier to find. I also deleted the now unnecessary methods to retrieve SMPL nodes in `scene.py`